### PR TITLE
Redis container restart, Storing task args, Admin Panel Celery Logs

### DIFF
--- a/backend/main/admin.py
+++ b/backend/main/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Event, Faculty_Advisor, Organisation, Faculty_Org, Certificate, Faculty_Event
+from .models import Event, Faculty_Advisor, Organisation, Faculty_Org, Certificate, Faculty_Event, EmailTaskLog
 
 class EventAdmin(admin.ModelAdmin):
   list_display = ['organisation', 'event_name', 'isCDC']
@@ -21,3 +21,9 @@ admin.site.register(Organisation)
 admin.site.register(Faculty_Org, FacultyOrgAdmin)
 admin.site.register(Certificate, CertificateAdmin)
 admin.site.register(Faculty_Event)
+
+@admin.register(EmailTaskLog)
+class EmailTaskLogAdmin(admin.ModelAdmin):
+    list_display = ('recipient_email', 'subject', 'status', 'retries', 'created_at', 'completed_at')
+    list_filter = ('status', 'created_at')
+    search_fields = ('recipient_email', 'subject', 'task_id')

--- a/backend/main/admin.py
+++ b/backend/main/admin.py
@@ -27,3 +27,5 @@ class EmailTaskLogAdmin(admin.ModelAdmin):
     list_display = ('recipient_email', 'subject', 'status', 'retries', 'created_at', 'completed_at')
     list_filter = ('status', 'created_at')
     search_fields = ('recipient_email', 'subject', 'task_id')
+    ordering = ('-created_at',)
+    readonly_fields = ('task_id', 'created_at', 'completed_at', 'retries', 'error_message')

--- a/backend/main/models.py
+++ b/backend/main/models.py
@@ -15,6 +15,19 @@ def event_data_upload_path(instance, filename):
 def certificate_upload_path(instance, filename):
   return f'events_db/{instance.organisation}/{instance.event_name}/certificate/{filename}'
 
+class EmailTaskLog(models.Model):
+  task_id = models.CharField(max_length=100, blank=True, null=True)
+  subject = models.CharField(max_length=255)
+  body = models.TextField()
+  recipient_email = models.EmailField()
+  status = models.CharField(max_length=20, choices=[("STARTED", "STARTED"), ("SUCCESS", "SUCCESS"), ("FAILED", "FAILED")])
+  error_message = models.TextField(blank=True, null=True)
+  retries = models.IntegerField(default=0)
+  created_at = models.DateTimeField()
+  completed_at = models.DateTimeField(blank=True, null=True)
+
+  def __str__(self):
+      return f"{self.recipient_email} - {self.status} - {self.subject}"
 
 class Organisation(models.Model):
   class Meta:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -40,6 +40,7 @@ services:
       - "8080:80"
   redis:
     image: redis:latest
+    restart: always
 
   celery_worker:
     image: technocracynitrr/dig-cert-nitrr-backend:latest


### PR DESCRIPTION
- Redis container always restart
- Storing args of send_email_queue task
- Django Admin Panel for Celery Task Logs